### PR TITLE
Fix typo and control .remarkrc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,6 @@
 
 # Don't change me! Compliance team is the owner of these files
 /.github/                   @saic-oss/compliance
-/Taskfile.yaml              @saic-oss/compliance
+/Taskfile.yml               @saic-oss/compliance
 /.pre-commit-config.yaml    @saic-oss/compliance
+/.remarkrc                  @saic-oss/compliance


### PR DESCRIPTION
## what
- Fix typo (.yaml -> .yml)
- Make @saic-oss/compliance the codeowner of .remarkrc

## why
- It doesn't actually matter in this case, since @saic-oss/compliance is already the owner of the whole project, but it's happening anyway so they are the same across all repos
